### PR TITLE
Ensure canonical language handles power swipe navigation

### DIFF
--- a/src/components/flags.rs
+++ b/src/components/flags.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::{prelude::Closure, JsCast};
 use web_sys::{console, window, HtmlElement, MouseEvent};
 use yew::{html, Callback, Event, Html, NodeRef, UseStateHandle};
 
-use super::lang::Language;
+use super::lang::{language_handle, Language};
 use crate::state::State;
 
 fn flag_button(
@@ -14,12 +14,12 @@ fn flag_button(
     card_ref: NodeRef,
     classes: String,
 ) -> Html {
-    let flag_lang_clone = Arc::clone(&flag_lang);
+    let flag_lang_clone = flag_lang;
     let animation_in_progress = Rc::new(RefCell::new(false));
 
     let onclick = Callback::from({
         let card_ref = card_ref.clone();
-        let flag_lang_clone = flag_lang_clone.clone();
+        let flag_lang_clone = Arc::clone(&flag_lang_clone);
         let animation_in_progress = animation_in_progress.clone();
         move |_: MouseEvent| {
             if let Some(target) = card_ref.cast::<HtmlElement>() {
@@ -42,7 +42,7 @@ fn flag_button(
                 let animation_in_progress_clone = animation_in_progress.clone();
                 let handle = Closure::wrap(Box::new(move || {
                     if *animation_in_progress_clone.borrow() {
-                        set_language.emit(flag_lang_clone.clone());
+                        set_language.emit(Arc::clone(&flag_lang_clone));
                     }
                 }) as Box<dyn FnMut()>);
 
@@ -113,18 +113,23 @@ pub fn render_flags(
     set_language: Callback<Arc<Language>>,
     card_ref: NodeRef,
 ) -> Html {
+    let korean = language_handle(Language::Korean);
+    let english = language_handle(Language::English);
+    let russian = language_handle(Language::Russian);
+    let vietnamese = language_handle(Language::Vietnamese);
+
     html! {
         <>
-            { flag_button(Arc::new(Language::Korean), "../images/flags/kr.svg".to_string(), set_language.clone(), card_ref.clone(), get_flag_class(&state.language, &Language::Korean)) }
-            { flag_button(Arc::new(Language::English), "../images/flags/us.svg".to_string(), set_language.clone(), card_ref.clone(), get_flag_class(&state.language, &Language::English)) }
-            { flag_button(Arc::new(Language::Russian), "../images/flags/ru.svg".to_string(), set_language.clone(), card_ref.clone(), get_flag_class(&state.language, &Language::Russian)) }
-            { flag_button(Arc::new(Language::Vietnamese), "../images/flags/vn.svg".to_string(), set_language.clone(), card_ref.clone(), get_flag_class(&state.language, &Language::Vietnamese)) }
+            { flag_button(Arc::clone(&korean), "../images/flags/kr.svg".to_string(), set_language.clone(), card_ref.clone(), get_flag_class(&state.language, Language::Korean)) }
+            { flag_button(Arc::clone(&english), "../images/flags/us.svg".to_string(), set_language.clone(), card_ref.clone(), get_flag_class(&state.language, Language::English)) }
+            { flag_button(Arc::clone(&russian), "../images/flags/ru.svg".to_string(), set_language.clone(), card_ref.clone(), get_flag_class(&state.language, Language::Russian)) }
+            { flag_button(Arc::clone(&vietnamese), "../images/flags/vn.svg".to_string(), set_language.clone(), card_ref.clone(), get_flag_class(&state.language, Language::Vietnamese)) }
         </>
     }
 }
 
-fn get_flag_class(current_language: &Arc<Language>, language: &Language) -> String {
-    if **current_language == *language {
+fn get_flag_class(current_language: &Arc<Language>, language: Language) -> String {
+    if **current_language == language {
         "active-flag".to_string()
     } else {
         "".to_string()

--- a/src/components/lang/mod.rs
+++ b/src/components/lang/mod.rs
@@ -7,7 +7,7 @@ pub mod korean;
 pub mod russian;
 pub mod vietnam;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Language {
     Korean,
     English,
@@ -15,11 +15,11 @@ pub enum Language {
     Vietnamese,
 }
 
-static LANGUAGES: OnceLock<Vec<Arc<Language>>> = OnceLock::new();
+static LANGUAGES: OnceLock<[Arc<Language>; 4]> = OnceLock::new();
 
-fn init_languages() -> &'static Vec<Arc<Language>> {
+fn init_languages() -> &'static [Arc<Language>; 4] {
     LANGUAGES.get_or_init(|| {
-        vec![
+        [
             Arc::new(Language::Korean),
             Arc::new(Language::English),
             Arc::new(Language::Russian),
@@ -28,29 +28,99 @@ fn init_languages() -> &'static Vec<Arc<Language>> {
     })
 }
 
-pub fn get_next_language(current: &Arc<Language>, direction: SwipeDirection) -> Arc<Language> {
-    let languages = init_languages();
-    if let Some(current_index) = languages.iter().position(|lang| Arc::ptr_eq(lang, current)) {
-        let next_index = get_next_language_index(current_index, direction);
-        Arc::clone(&languages[next_index])
-    } else {
-        Arc::clone(&languages[0])
+fn language_index(language: Language) -> usize {
+    match language {
+        Language::Korean => 0,
+        Language::English => 1,
+        Language::Russian => 2,
+        Language::Vietnamese => 3,
     }
 }
 
-fn get_next_language_index(current_index: usize, direction: SwipeDirection) -> usize {
-    if let Some(languages) = LANGUAGES.get() {
-        match direction {
-            SwipeDirection::Right => (current_index + 1) % languages.len(),
-            SwipeDirection::Left => {
-                if current_index == 0 {
-                    languages.len() - 1
-                } else {
-                    current_index - 1
-                }
+/// Returns the canonical shared [`Arc`] handle for the provided [`Language`].
+///
+/// # Examples
+/// ```
+/// use business_card::components::lang::{language_handle, Language};
+///
+/// let english = language_handle(Language::English);
+/// assert_eq!(*english, Language::English);
+/// ```
+pub fn language_handle(language: Language) -> Arc<Language> {
+    let languages = init_languages();
+    Arc::clone(&languages[language_index(language)])
+}
+
+/// Finds the next language handle in the swipe direction relative to the current selection.
+///
+/// # Examples
+/// ```
+/// use business_card::components::lang::{get_next_language, language_handle, Language};
+/// use business_card::touch_handler::SwipeDirection;
+///
+/// let english = language_handle(Language::English);
+/// let next = get_next_language(&english, SwipeDirection::Right);
+/// assert_eq!(*next, Language::Russian);
+/// ```
+pub fn get_next_language(current: &Arc<Language>, direction: SwipeDirection) -> Arc<Language> {
+    let languages = init_languages();
+    let current_index = language_index(**current);
+    let next_index = get_next_language_index(current_index, languages.len(), direction);
+    Arc::clone(&languages[next_index])
+}
+
+fn get_next_language_index(
+    current_index: usize,
+    total_languages: usize,
+    direction: SwipeDirection,
+) -> usize {
+    if total_languages == 0 {
+        return 0;
+    }
+
+    match direction {
+        SwipeDirection::Right => (current_index + 1) % total_languages,
+        SwipeDirection::Left => {
+            if current_index == 0 {
+                total_languages - 1
+            } else {
+                current_index - 1
             }
         }
-    } else {
-        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{state::State, touch_handler::SwipeDirection};
+
+    #[test]
+    fn default_state_uses_canonical_english_language() {
+        let state = State::default();
+        let english = language_handle(Language::English);
+
+        assert!(Arc::ptr_eq(&state.language, &english));
+    }
+
+    #[test]
+    fn swipes_from_english_visit_expected_neighbors() {
+        let english = language_handle(Language::English);
+
+        let left_neighbor = get_next_language(&english, SwipeDirection::Left);
+        assert_eq!(*left_neighbor, Language::Korean);
+        assert!(Arc::ptr_eq(
+            &left_neighbor,
+            &language_handle(Language::Korean)
+        ));
+
+        let right_neighbor = get_next_language(&english, SwipeDirection::Right);
+        assert_eq!(*right_neighbor, Language::Russian);
+        assert!(Arc::ptr_eq(
+            &right_neighbor,
+            &language_handle(Language::Russian)
+        ));
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use yew::{use_state, Hook, UseStateHandle};
 
-use crate::components::lang::Language;
+use crate::components::lang::{language_handle, Language};
 
 pub struct State {
     pub language: Arc<Language>,
@@ -13,7 +13,7 @@ pub struct State {
 impl Default for State {
     fn default() -> Self {
         Self {
-            language: Arc::new(Language::English),
+            language: language_handle(Language::English),
             is_rotating: false,
             is_content_visible: true,
         }


### PR DESCRIPTION
## Summary
- add a canonical language registry and accessor so state and UI reuse stable handles
- update swipe navigation to resolve the next language by enum value instead of pointer identity
- cover default language selection and swipe neighbors with regression tests

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps


------
https://chatgpt.com/codex/tasks/task_e_68e0d2b6370c832b8722ef1be2e2d7c5